### PR TITLE
Update getExampleData.R

### DIFF
--- a/R/getExampleData.R
+++ b/R/getExampleData.R
@@ -1,109 +1,130 @@
 #' Downloads and installs the WIAD Example Dataset
-#' 
+#'
 #' The WIAD Example Dataset can be downloaded from https://wiad.science/WIAD_ExampleData.zip .
 #' This function downloads and extracts the WIAD Example Dataset in the package folder.
-#' 
-#' @param mode \code{"install"} (default),\code{"update"} or \code{"remove"} 
-#' @param downloadPath custom location to temporarily store WIAD example dataset while downloading. Default: tempdir() 
+#'
+#' @param mode \code{"install"} (default),\code{"update"} or \code{"remove"}
+#' @param downloadPath custom location to temporarily store WIAD example dataset while downloading. Default: \code{tempdir()}
 #' @param installPath custom location to place WIAD example dataset. Default: WIAD package directory
+#' @param dataset  choose to download the \code{"small"} example dataset (248 MB) or the  \code{"full"} example dataset (1.83 GB). Default: \code{"small"}
 #' @return No return value
 #' @importFrom utils download.file
 #' @export
-#' 
-getExampleData <-function(mode = "install", 
+#'
+getExampleData <-function(mode = "install",
                           downloadPath = tempdir(),
-                          installPath = ""){
+                          installPath = "",
+                          dataset="small"){
+
   # URLS and PATHS
-  url <-
-    "https://wiad.science/WIAD_ExampleData.zip"
-  
-  
-  
-  localzipfile <- 
-    file.path(
-      downloadPath,
-      "WIAD_ExampleData.zip"
-    )
-  
   if (
-    installPath == 
+    dataset ==
+      "small"
+  ) {
+    url <-
+      "https://wiad.science/WIAD_ExampleData_small.zip"
+    msg<-"Downloading small WIAD Example Datset (248 MB).
+        This may take a while...\n
+        To get the full WIAD Example Datset (1.83 GB) run getExampleData('update',dataset='full')\n"
+
+    localzipfile <-
+      file.path(
+        downloadPath,
+        "WIAD_ExampleData_small.zip"
+      )
+
+  } else {
+    url <-
+      "https://wiad.science/WIAD_ExampleData.zip"
+    msg<-"Downloading full WIAD Example Datset (1.83 GB).
+        This may take a while...\n"
+
+    localzipfile <-
+      file.path(
+        downloadPath,
+        "WIAD_ExampleData.zip"
+      )
+
+  }
+
+  if (
+    installPath ==
     ""
-  ) 
-    installPath  <- 
+  )
+    installPath  <-
     system.file(
-      package 
-      = 
+      package
+      =
         "wiad"
     ) # DEFINE PACKAGE NAME HERE
-  
-  exampleDataPath <- 
+
+  exampleDataPath <-
     file.path(
       installPath,
       "ExampleData"
     )
-  
+
   if (mode
-      %in% 
+      %in%
       c(
         "install",
         "update"
       )
   )
   {
-    
+
     # Download is started only if /ExampleDataset path does not yet exist or if mode=="update"
     if (
       !dir.exists(
         exampleDataPath
-      ) 
+      )
       ||
-      mode 
+      mode
       ==
       "update"
-    ) 
+    )
     {
-      
+
       # DOWNLOAD
       message(
-        "Downloading WIAD Example Datset (1.83 GB). 
-        This may take a while...\n"
+        msg
         )
-      
-      
+
+
       if(
         file.exists(
           localzipfile
-        ) 
+        )
         &&
-        mode 
-        != 
+        mode
+        !=
         'update'
-        ) 
-        url = 
+        )
+        url =
           'http://example.com/' # for testing routines
-      
-      dl <- 
+
+      dl <-
         try(
           download.file(
-            url = 
-              url, 
+            url =
+              url,
             destfile =
-              localzipfile, 
-            quiet = 
-              FALSE, 
+              localzipfile,
+            quiet =
+              FALSE,
             mode = "wb"
           )
         )
-      
+
       if(
-        !is.null(attr(dl, "class")) 
-        && 
-        attr(dl, "class") == 
+        !is.null(attr(dl, "class"))
+        &&
+        attr(dl, "class") ==
         "try-error"
       ){
         message("Unable to download data for URL:", url, "\n"); return()
       }
-      
+
       if (
         file.exists(
           localzipfile
@@ -114,46 +135,46 @@ getExampleData <-function(mode = "install",
         message (
           "Extracting WIAD Example Dataset\n"
           )
-        
+
         utils::unzip(
           zipfile =
-            localzipfile, 
-          exdir = 
-            installPath, 
-          overwrite = 
+            localzipfile,
+          exdir =
+            installPath,
+          overwrite =
             TRUE)
-        
+
         # CLEANUP
         message (
           "Cleanup\n"
           )
-        
+
         unlink(
-          x = 
+          x =
             localzipfile,
-          recursive = 
+          recursive =
             FALSE
           )
-        
+
         message(
           "sucessfully installed WIAD Example Dataset to ",
           exampleDataPath,
           '\n')
-        
+
       } else {
         message ('Unable to extract WIAD Example Dataset: file not found\n')
       }
     } else {
       message(
-        'WIAD Example Dataset is already installed\n'
+        'WIAD Example Dataset is already installed. Set mode="update" to reinstall the dataset\n'
       )
     }
-    
+
     # DO STUFF HERE TO SET AS ACTIVE DATASET
-    
+
   } else if (
-    mode 
-    == 
+    mode
+    ==
     "remove"
   ){
     # ATTENTION: Will remove the example dataset folder without further warning
@@ -162,21 +183,21 @@ getExampleData <-function(mode = "install",
         exampleDataPath
       )
     ) {
-      
+
       unlink(
         exampleDataPath,
-        recursive = 
+        recursive =
           TRUE)
-      
+
       message(
         'Sucessfully removed WIAD Example Dataset\n'
       )
-      
+
     }else{
       message(
         'Cannot remove WIAD Example Dataset: Dataset not found\n'
       )
     }
   }
-  
+
 }


### PR DESCRIPTION
Added the option to choose to download the small 250MB example dataset or the full 1.84 GB Example dataset. Currently, the default is to download the small dataset and display a message on how to get the full dataset. 